### PR TITLE
Abort havoc on fatal errors; improve error messages; add a process storm event to havoc

### DIFF
--- a/test.c
+++ b/test.c
@@ -296,18 +296,30 @@ int test_havoc(int numprocs){
   int* allocated = calloc(numprocs + 1, 4);
   int remaining_allocation = 100;
   
-  srand(0);
+  srand(120);
   
   for(int t = 0; t < 1000000; t++) {
     // Start a new process?
-    if(pid_top < numprocs && !(rand() % 900)) {
+    if(pid_top < numprocs && !(rand() % 1100)) {
 
       if(!StartingProc(++pid_top)) {
 	Printf("StartingProc failed\n");
-	errors++;
+	return ++errors;
       }
       // Printf("Started new process %d\n", pid_top);
       last_event = t;
+    }
+
+    // Start as many new processes as possible?
+    if(!(rand() % 50000)) {
+      while(pid_top < numprocs){
+	if(!StartingProc(++pid_top)) {
+	  Printf("StartingProc failed\n");
+	  return ++errors;
+	}
+	// Printf("Started new process %d\n", pid_top);
+	last_event = t;
+      }
     }
     
     // End the last process?
@@ -325,7 +337,7 @@ int test_havoc(int numprocs){
       
       if(!EndingProc(pid_top--)) {
 	Printf("EndingProc failed\n");
-	errors++;
+	return ++errors;
       }
       
       last_event = t;
@@ -337,18 +349,19 @@ int test_havoc(int numprocs){
       int max_allocation = remaining_allocation + allocated[pid];
 
       if(MyRequestCPUrate(pid, max_allocation + 1) != -1) {	
-	Printf("Didn't reject overallocation request of %d\n", max_allocation+1);
-	errors++;
+	Printf("Failed to reject overallocation request of %d for process %d\n",
+	       max_allocation+1, pid);
+	return ++errors;
       }
 
       if(max_allocation) {
 	int new_allocation = 1 + rand() % max_allocation;
 
 	// Printf("Changing allocation of %d: %d -> %d\n", pid, allocated[pid], new_allocation);
-      
 	if(MyRequestCPUrate(pid, new_allocation) != 0){
-	  Printf("Rejected valid request (remaining %d)\n", remaining_allocation);
-	  errors++;
+	  Printf("Failed to accept valid request of %d for process %d; should have been able to request up to %d\n",
+		 new_allocation, pid, max_allocation);
+	  return ++errors;
 	}
       
 	remaining_allocation += allocated[pid] - new_allocation;
@@ -368,7 +381,7 @@ int test_havoc(int numprocs){
       
       for(int i = 1; i <= numprocs; i++){
 	if(!inSlackRange(allocated[i], totals[i])) {
-	  Printf("Process %d received %d ticks; expected at least %d\n", i, totals[i], allocated[i]);
+	  Printf("Process %d received %d of the last 100 ticks, but requested %d\n", i, totals[i], allocated[i]);
 	  errors++;
 	}
       }

--- a/test.c
+++ b/test.c
@@ -303,7 +303,7 @@ int test_havoc(int numprocs){
     if(pid_top < numprocs && !(rand() % 1100)) {
 
       if(!StartingProc(++pid_top)) {
-	Printf("StartingProc failed\n");
+	Printf("HAVOC ERR: StartingProc failed\n");
 	return ++errors;
       }
       // Printf("Started new process %d\n", pid_top);
@@ -314,7 +314,7 @@ int test_havoc(int numprocs){
     if(!(rand() % 50000)) {
       while(pid_top < numprocs){
 	if(!StartingProc(++pid_top)) {
-	  Printf("StartingProc failed\n");
+	  Printf("HAVOC ERR: StartingProc failed\n");
 	  return ++errors;
 	}
 	// Printf("Started new process %d\n", pid_top);
@@ -336,7 +336,7 @@ int test_havoc(int numprocs){
       // Printf("Ending process %d\n", pid_top);	    
       
       if(!EndingProc(pid_top--)) {
-	Printf("EndingProc failed\n");
+	Printf("HAVOC ERR: EndingProc failed\n");
 	return ++errors;
       }
       
@@ -349,7 +349,7 @@ int test_havoc(int numprocs){
       int max_allocation = remaining_allocation + allocated[pid];
 
       if(MyRequestCPUrate(pid, max_allocation + 1) != -1) {	
-	Printf("Failed to reject overallocation request of %d for process %d\n",
+	Printf("HAVOC ERR: Failed to reject overallocation request of %d for process %d\n",
 	       max_allocation+1, pid);
 	return ++errors;
       }
@@ -359,7 +359,7 @@ int test_havoc(int numprocs){
 
 	// Printf("Changing allocation of %d: %d -> %d\n", pid, allocated[pid], new_allocation);
 	if(MyRequestCPUrate(pid, new_allocation) != 0){
-	  Printf("Failed to accept valid request of %d for process %d; should have been able to request up to %d\n",
+	  Printf("HAVOC ERR: Failed to accept valid request of %d for process %d; should have been able to request up to %d\n",
 		 new_allocation, pid, max_allocation);
 	  return ++errors;
 	}
@@ -381,7 +381,7 @@ int test_havoc(int numprocs){
       
       for(int i = 1; i <= numprocs; i++){
 	if(!inSlackRange(allocated[i], totals[i])) {
-	  Printf("Process %d received %d of the last 100 ticks, but requested %d\n", i, totals[i], allocated[i]);
+	  Printf("HAVOC ERR: Process %d received %d of the last 100 ticks, but requested %d\n", i, totals[i], allocated[i]);
 	  errors++;
 	}
       }


### PR DESCRIPTION
With 1/50000 probability, start up as many processes as allowed. This commit also adjusts the probability of ending a process to be slightly higher than starting one so the process count doesn't always tend towards MAXPROCS.

Showing 7 processes starting at once:

![image](https://cloud.githubusercontent.com/assets/5904167/12624436/e9a4373c-c4e3-11e5-87db-bbd31f88fd1b.png)
