### PR TITLE
test_proportional_split_amongst_procs

### DIFF
--- a/test.c
+++ b/test.c
@@ -393,6 +393,13 @@ int test_proportional_huge(int numprocs) {
   return failCounter;
 }
 
+
+/*
+ * A simple test case to ensure that any processes with no CPU allocation 
+ * don't take too much CPU, even if there is less than 1% to go around. Also 
+ * ensures that 1% is appropriately split among processes with no CPU 
+ * allocation.
+ */
 int test_proportional_split_amongst_procs(int numprocs) {
   int failCounter = 0;
   SetSchedPolicy(PROPORTIONAL);

--- a/test.c
+++ b/test.c
@@ -400,7 +400,9 @@ int test_proportional_split_amongst_procs(int numprocs) {
   int i, iter;
   int counts[numprocs+1];
   int numRecvd = 0;
-  /* Printf("start\n"); */
+
+  if (verbose)
+    Printf("start PROPORTIONALSPLIT with %d procs\n", numprocs);
 
   for (i = 1; i <= numprocs; i++) {
     StartingProc(i);
@@ -422,9 +424,11 @@ int test_proportional_split_amongst_procs(int numprocs) {
     failCounter++;
   }
 
-  /* Printf("%d recvd %d\n", 1, counts[1]); */
+  if (verbose)
+    Printf("proc %d recvd %d ticks\n", 1, counts[1]);
   for (i = 2; i <= numprocs; i++) {
-    /* Printf("%d recvd %d\n", i, counts[i]); */
+    if (verbose)
+      Printf("proc %d recvd %d ticks\n", i, counts[i]);
     if (counts[i] >= 1) {
       numRecvd++;
     }
@@ -441,7 +445,7 @@ int test_proportional_split_amongst_procs(int numprocs) {
     EndingProc(i);
 
   if (get_next_sched()) {
-    Printf("PROPORTIONAL3 ERR: Not all processes have exited\n");
+    Printf("PROPORTIONALSPLIT ERR: Not all processes have exited\n");
     failCounter++;
   }
 

--- a/test.c
+++ b/test.c
@@ -66,7 +66,7 @@ int test_fifo_normal(int numprocs) {
     }
 
     EndingProc(proc);
-  } 
+  }
 
   /* check if all process are exited */
   if (get_next_sched()) {

--- a/test.c
+++ b/test.c
@@ -305,6 +305,7 @@ int test_proportional_split_amongst_procs(int numprocs) {
   int i, iter;
   int counts[numprocs+1];
   int numRecvd = 0;
+  /* Printf("start\n"); */
 
   for (i = 1; i <= numprocs; i++) {
     StartingProc(i);
@@ -326,13 +327,15 @@ int test_proportional_split_amongst_procs(int numprocs) {
     failCounter++;
   }
 
+  /* Printf("%d recvd %d\n", 1, counts[1]); */
   for (i = 2; i <= numprocs; i++) {
+    /* Printf("%d recvd %d\n", i, counts[i]); */
     if (counts[i] >= 1) {
       numRecvd++;
     }
   }
 
-  if (numRecvd < 5) {
+  if (numprocs >= 6 && numRecvd < 5) {
     Printf("PROPORTIONALSPLIT ERR:" 
         " At >5 procs should have received a cpu tick"
         " since process 1 requested 99%%\n");

--- a/test.c
+++ b/test.c
@@ -431,14 +431,11 @@ int test_proportional_split_amongst_procs(int numprocs) {
     failCounter++;
   }
 
-  if (verbose)
-    Printf("proc %d recvd %d ticks\n", 1, counts[1]);
-  for (i = 2; i <= numprocs; i++) {
+  for (i = 1; i <= numprocs; i++) {
     if (verbose)
       Printf("proc %d recvd %d ticks\n", i, counts[i]);
-    if (counts[i] >= 1) {
+    if (i > 1 && counts[i] >= 1)
       numRecvd++;
-    }
   }
 
   if (numprocs >= 6 && numRecvd < 5) {


### PR DESCRIPTION
A simple test case to ensure that any processes with no CPU allocation don't take too much CPU, even if there is less than 1% to go around. Also ensures that 1% is appropriately split among processes with no CPU allocation.
