### PR TITLE
A rate request - even for the same amount - is a "special event."

### DIFF
--- a/test.c
+++ b/test.c
@@ -476,12 +476,14 @@ int test_proportional_reqhog(int numprocs) {
     counts[i] = 0;
   }
 
-  for (iter = 0; iter < 500; iter++) {
+   for (iter = 0; iter < 500; iter++) {
     if (MyRequestCPUrate(1, 90) == -1) {
       Printf("PROPORTIONALREQHOG ERR: MyRequestCPUrate returned -1 when CPU was available\n");
       failCounter++;
-    }
+    } 
+  }
 
+  for (iter = 0; iter < 500; iter++) {
     counts[get_next_sched()]++;
   }
 

--- a/test.c
+++ b/test.c
@@ -476,7 +476,7 @@ int test_proportional_reqhog(int numprocs) {
     counts[i] = 0;
   }
 
-   for (iter = 0; iter < 500; iter++) {
+  for (iter = 0; iter < 500; iter++) {
     if (MyRequestCPUrate(1, 90) == -1) {
       Printf("PROPORTIONALREQHOG ERR: MyRequestCPUrate returned -1 when CPU was available\n");
       failCounter++;


### PR DESCRIPTION
Q: if process A has 50% CPU rate.  It requests 50% again.  Does this restart the steady-state count of 100 quantum?

the instructors' answer:
 * We will only test to determine correct target CPU utilizations during
 * periods of "steady state," defined as a period of 100 or more quantums
 * during which no special events occur, AND that comes after a period of
 * at least 100 quantums during which no special events occur, where a
 * special event is a process creation, exit, or rate request.

Given the above, a rate request - even for the same amount - is a "special event."
See https://piazza.com/class/k51m7y75yswei?cid=248